### PR TITLE
Redirect to docs page

### DIFF
--- a/Chrome Extension/src/bg/background.js
+++ b/Chrome Extension/src/bg/background.js
@@ -13,5 +13,5 @@
 // });
 
 chrome.runtime.onInstalled.addListener(function(object) {
-  chrome.tabs.create({url: 'views/instructions.html'});
+  chrome.tabs.create({url: 'https://docs.circuitverse.org/#/embedding_circuits?id=embedding-in-google-slides'});
 });

--- a/Chrome Extension/views/instructions.html
+++ b/Chrome Extension/views/instructions.html
@@ -1,8 +1,0 @@
-<!DOCTYPE html>
-<html>
-<head>
-</head>
-<body>
-    Welcome to CircuitVerse. Install the chrome extension + Google Slides Add On.
-</body>
-</html>

--- a/Firefox Extension/src/bg/background.js
+++ b/Firefox Extension/src/bg/background.js
@@ -13,5 +13,5 @@
 // });
 
 chrome.runtime.onInstalled.addListener(function(object) {
-  chrome.tabs.create({url: 'views/instructions.html'});
+  chrome.tabs.create({url: 'https://docs.circuitverse.org/#/embedding_circuits?id=embedding-in-google-slides'});
 });

--- a/Firefox Extension/views/instructions.html
+++ b/Firefox Extension/views/instructions.html
@@ -1,8 +1,0 @@
-<!DOCTYPE html>
-<html>
-<head>
-</head>
-<body>
-    Welcome to CircuitVerse. Install the chrome extension + Google Slides Add On.
-</body>
-</html>


### PR DESCRIPTION
@aryanbaburajan check this PR.

I created detailed instructions here: https://docs.circuitverse.org/#/embedding_circuits?id=embedding-in-google-slides
And referencing them in the extension. I think this is better as it will allow us to update the instructions easily. 

However having a dedicated instruction page might make it feel easier for the user. What do you say? 

@Shivansh2407 @sal2701 any inputs here? 